### PR TITLE
refactor: e-collecting web component name to owlly-collect

### DIFF
--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -6,7 +6,7 @@
  */
 import { HTMLStencilElement, JSXBase } from "@stencil/core/internal";
 export namespace Components {
-    interface ECollecting {
+    interface OwllyCollect {
         /**
           * Style the button with a dark or light theme?
          */
@@ -26,18 +26,18 @@ export namespace Components {
     }
 }
 declare global {
-    interface HTMLECollectingElement extends Components.ECollecting, HTMLStencilElement {
+    interface HTMLOwllyCollectElement extends Components.OwllyCollect, HTMLStencilElement {
     }
-    var HTMLECollectingElement: {
-        prototype: HTMLECollectingElement;
-        new (): HTMLECollectingElement;
+    var HTMLOwllyCollectElement: {
+        prototype: HTMLOwllyCollectElement;
+        new (): HTMLOwllyCollectElement;
     };
     interface HTMLElementTagNameMap {
-        "e-collecting": HTMLECollectingElement;
+        "owlly-collect": HTMLOwllyCollectElement;
     }
 }
 declare namespace LocalJSX {
-    interface ECollecting {
+    interface OwllyCollect {
         /**
           * Style the button with a dark or light theme?
          */
@@ -56,14 +56,14 @@ declare namespace LocalJSX {
         "owllyId"?: string;
     }
     interface IntrinsicElements {
-        "e-collecting": ECollecting;
+        "owlly-collect": OwllyCollect;
     }
 }
 export { LocalJSX as JSX };
 declare module "@stencil/core" {
     export namespace JSX {
         interface IntrinsicElements {
-            "e-collecting": LocalJSX.ECollecting & JSXBase.HTMLAttributes<HTMLECollectingElement>;
+            "owlly-collect": LocalJSX.OwllyCollect & JSXBase.HTMLAttributes<HTMLOwllyCollectElement>;
         }
     }
 }

--- a/src/components/e-collecting/e-collecting.e2e.ts
+++ b/src/components/e-collecting/e-collecting.e2e.ts
@@ -4,16 +4,16 @@ describe('e-collecting', () => {
   it('renders', async () => {
     const page = await newE2EPage();
 
-    await page.setContent('<e-collecting></e-collecting>');
-    const element = await page.find('e-collecting');
+    await page.setContent('<owlly-collect></owlly-collect>');
+    const element = await page.find('owlly-collect');
     expect(element).toHaveClass('hydrated');
   });
 
   it('renders custom text', async () => {
     const page = await newE2EPage();
 
-    await page.setContent('<e-collecting>Hello World</e-collecting>');
-    const component = await page.find('e-collecting');
+    await page.setContent('<owlly-collect>Hello World</owlly-collect>');
+    const component = await page.find('owlly-collect');
     expect(component.textContent).toEqual(`Hello World`);
   });
 
@@ -33,8 +33,8 @@ describe('e-collecting', () => {
       });
     });
 
-    await page.setContent('<e-collecting></e-collecting>');
-    const component = await page.find('e-collecting >>> button');
+    await page.setContent('<owlly-collect></owlly-collect>');
+    const component = await page.find('owlly-collect >>> button');
 
     expect(component.textContent).toEqual(`unterschreiben`);
   });

--- a/src/components/e-collecting/e-collecting.spec.ts
+++ b/src/components/e-collecting/e-collecting.spec.ts
@@ -58,11 +58,11 @@ describe('e-collecting', () => {
   it('renders', async () => {
     const {root} = await newSpecPage({
       components: [ECollecting],
-      html: '<e-collecting></e-collecting>',
+      html: '<owlly-collect></owlly-collect>',
     });
 
     expect(root).toEqualHtml(`
-      <e-collecting mode="light">
+      <owlly-collect mode="light">
         <mock:shadow-root>
           ${mockStyleLight}
           <button disabled="" part="button">
@@ -70,17 +70,17 @@ describe('e-collecting', () => {
             <slot>sign</slot>
           </button>
         </mock:shadow-root>
-      </e-collecting>
+      </owlly-collect>
     `);
   });
 
   it('renders with custom text', async () => {
     const {root} = await newSpecPage({
       components: [ECollecting],
-      html: '<e-collecting>Hello World</e-collecting>',
+      html: '<owlly-collect>Hello World</owlly-collect>',
     });
     expect(root).toEqualHtml(`
-      <e-collecting mode="light">
+      <owlly-collect mode="light">
         <mock:shadow-root>
           ${mockStyleLight}
           <button disabled="" part="button">
@@ -89,7 +89,7 @@ describe('e-collecting', () => {
           </button>
         </mock:shadow-root>
         Hello World
-      </e-collecting>
+      </owlly-collect>
     `);
   });
 
@@ -98,10 +98,10 @@ describe('e-collecting', () => {
 
     const {root} = await newSpecPage({
       components: [ECollecting],
-      html: `<e-collecting owlly-id="${owllyId}"></e-collecting>`,
+      html: `<owlly-collect owlly-id="${owllyId}"></owlly-collect>`,
     });
     expect(root).toEqualHtml(`
-      <e-collecting mode="light" owlly-id="${owllyId}">
+      <owlly-collect mode="light" owlly-id="${owllyId}">
         <mock:shadow-root>
           ${mockStyleLight}
           <button aria-label="${owllyMock.title}" part="button">
@@ -110,18 +110,18 @@ describe('e-collecting', () => {
           </button>
           <a aria-hidden="true" href="https://owly.ch${owllyMock.link}" rel="noopener noreferrer" target="_blank"></a>
         </mock:shadow-root>
-      </e-collecting>
+      </owlly-collect>
     `);
   });
 
   it('renders dark mode', async () => {
     const {root} = await newSpecPage({
       components: [ECollecting],
-      html: '<e-collecting mode="dark"></e-collecting>',
+      html: '<owlly-collect mode="dark"></owlly-collect>',
     });
 
     expect(root).toEqualHtml(`
-      <e-collecting mode="dark" mode="dark">
+      <owlly-collect mode="dark" mode="dark">
         <mock:shadow-root>
           ${mockStyleDark}
           <button disabled="" part="button">
@@ -129,7 +129,7 @@ describe('e-collecting', () => {
             <slot>sign</slot>
           </button>
         </mock:shadow-root>
-      </e-collecting>
+      </owlly-collect>
     `);
   });
 });

--- a/src/components/e-collecting/e-collecting.tsx
+++ b/src/components/e-collecting/e-collecting.tsx
@@ -12,7 +12,7 @@ import {Logo} from '../styles/logo';
  * @part button - The part attribute to access the button
  */
 @Component({
-  tag: 'e-collecting',
+  tag: 'owlly-collect',
   styleUrl: 'e-collecting.scss',
   shadow: true,
 })


### PR DESCRIPTION
`<e-collecting/>`  is not a super web component name as it does not contains  the project's name.

this PR refactor its name to `<owlly-collect/>`.